### PR TITLE
Fix bug in bash_profile.

### DIFF
--- a/roles/bash/files/bash_profile
+++ b/roles/bash/files/bash_profile
@@ -1,7 +1,7 @@
 # vim: set filetype=sh :
 
 # Source the .profile file, if it exists
-[ -r "~/.profile" ] && [ -f "~/.profile" ] && source "~/.profile"
+[ -r ~/.profile ] && [ -f ~/.profile ] && source ~/.profile
 
 # Source the .bashrc file, if it exists
-[ -r "~/.bashrc" ] && [ -f "~/.bashrc" ] && source "~/.bashrc"
+[ -r ~/.bashrc ] && [ -f ~/.bashrc ] && source ~/.bashrc


### PR DESCRIPTION
~ doesn't expand if it's quoted.
