### PR TITLE
Rename 'devbox' to 'kitchensink'

### DIFF
--- a/roles/bash/files/bashrc
+++ b/roles/bash/files/bashrc
@@ -270,18 +270,18 @@ function drma() {
 }
 
 # Bash function to attach to, or spin up a new (named) docker container
-function devbox () {
+function sink () {
   local boxname=$1
   local dockerimage=$2
   local workdir="/home/marvin"
 
   if [ -z "$boxname" ]; then
-    echo "usage: devbox <box name> [docker image]"
+    echo "usage: sink <box name> [docker image]"
     return 1
   fi
 
   if [ -z "$dockerimage" ]; then
-    dockerimage="quay.io/marvin/devbox"
+    dockerimage="quay.io/marvin/kitchensink"
   fi
 
   if [ -e "${HOME}/projects/${boxname}" ]; then

--- a/roles/macbook_setup/tasks/devbox.yml
+++ b/roles/macbook_setup/tasks/devbox.yml
@@ -1,8 +1,0 @@
----
-- name: 'symlink /home/marvin to /home/dev'
-  sudo: yes
-  file:
-    src: '/home/marvin'
-    dest: '/home/dev'
-    state: 'link'
-    force: 'yes'

--- a/roles/macbook_setup/tasks/main.yml
+++ b/roles/macbook_setup/tasks/main.yml
@@ -12,6 +12,5 @@
 - include: function_keys.yml
 - include: scripts.yml
 - include: sounds.yml
-- include: devbox.yml
 - include: netextender.yml
 - include: yubikey.yml


### PR DESCRIPTION
One more thing to note is that the 'dev' user no-longer exists.

See https://github.com/marvinpinto/kitchensink/pull/13 for more details.
